### PR TITLE
chore: update launchdarkly-server-sdk-ai-openai from ^0.1.0 to ^0.2.0

### DIFF
--- a/examples/bedrock_example.py
+++ b/examples/bedrock_example.py
@@ -2,7 +2,7 @@ import os
 import ldclient
 from ldclient import Context
 from ldclient.config import Config
-from ldai.client import LDAIClient, AIConfig, ModelConfig, ProviderConfig, LDMessage
+from ldai.client import LDAIClient, AICompletionConfigDefault, ModelConfig, ProviderConfig, LDMessage
 import boto3
 
 client = boto3.client("bedrock-runtime", region_name="us-east-1")
@@ -43,14 +43,14 @@ def main():
     # Pass a default for improved resiliency when the AI config is unavailable
     # or LaunchDarkly is unreachable; omit for a disabled default.
     # Example:
-    #   default = AIConfig(
+    #   default = AICompletionConfigDefault(
     #       enabled=True,
     #       model=ModelConfig(name='my-default-model'),
     #       provider=ProviderConfig(name='bedrock'),
     #       messages=[LDMessage(role='system', content='You are a helpful assistant.')],
     #   )
-    #   config_value, tracker = aiclient.config(ai_config_key, context, default, {'myUserVariable': "Testing Variable"})
-    config_value, tracker = aiclient.config(
+    #   config_value = aiclient.config(ai_config_key, context, default, {'myUserVariable': "Testing Variable"})
+    config_value = aiclient.config(
         ai_config_key,
         context,
         variables={'myUserVariable': "Testing Variable"}
@@ -69,7 +69,7 @@ def main():
     print("User Input:\n", USER_INPUT)
     chat_messages.append({'role': 'user', 'content': [{'text': USER_INPUT}]})
 
-    converse = tracker.track_bedrock_converse_metrics(
+    converse = config_value.tracker.track_bedrock_converse_metrics(
         client.converse(
             modelId=config_value.model.name,
             messages=chat_messages,

--- a/examples/gemini_example.py
+++ b/examples/gemini_example.py
@@ -2,7 +2,7 @@ import os
 import ldclient
 from ldclient import Context
 from ldclient.config import Config
-from ldai.client import LDAIClient, AIConfig, ModelConfig, ProviderConfig, LDMessage
+from ldai.client import LDAIClient, AICompletionConfigDefault, ModelConfig, ProviderConfig, LDMessage
 from ldai.tracker import TokenUsage
 from google import genai
 from google.genai import types
@@ -113,14 +113,14 @@ def main():
     # Pass a default for improved resiliency when the AI config is unavailable
     # or LaunchDarkly is unreachable; omit for a disabled default.
     # Example:
-    #   default = AIConfig(
+    #   default = AICompletionConfigDefault(
     #       enabled=True,
     #       model=ModelConfig(name='gemini-pro'),
     #       provider=ProviderConfig(name='google'),
     #       messages=[LDMessage(role='system', content='You are a helpful assistant.')],
     #   )
-    #   config_value, tracker = aiclient.config(ai_config_key, context, default, {'myUserVariable': "Testing Variable"})
-    config_value, tracker = aiclient.config(
+    #   config_value = aiclient.config(ai_config_key, context, default, {'myUserVariable': "Testing Variable"})
+    config_value = aiclient.config(
         ai_config_key,
         context,
         variables={'myUserVariable': "Testing Variable"}
@@ -144,7 +144,7 @@ def main():
     user_message = types.Content(role="user", parts=[types.Part(text=USER_INPUT)])
     messages.append(user_message)
 
-    completion = track_genai_metrics(tracker, lambda: client.models.generate_content(
+    completion = track_genai_metrics(config_value.tracker, lambda: client.models.generate_content(
         model=config_value.model.name,
         contents=messages,
         config=types.GenerateContentConfig(

--- a/examples/langchain_example.py
+++ b/examples/langchain_example.py
@@ -2,7 +2,7 @@ import os
 import ldclient
 from ldclient import Context
 from ldclient.config import Config
-from ldai.client import LDAIClient, AIConfig, ModelConfig, ProviderConfig, LDMessage
+from ldai.client import LDAIClient, AICompletionConfigDefault, ModelConfig, ProviderConfig, LDMessage
 from ldai.tracker import TokenUsage
 from langchain.chat_models import init_chat_model
 
@@ -86,14 +86,14 @@ def main():
     # Pass a default for improved resiliency when the AI config is unavailable
     # or LaunchDarkly is unreachable; omit for a disabled default.
     # Example:
-    #   default = AIConfig(
+    #   default = AICompletionConfigDefault(
     #       enabled=True,
     #       model=ModelConfig(name='gpt-4'),
     #       provider=ProviderConfig(name='openai'),
     #       messages=[LDMessage(role='system', content='You are a helpful assistant.')],
     #   )
-    #   config_value, tracker = aiclient.config(ai_config_key, context, default, {'myUserVariable': "Testing Variable"})
-    config_value, tracker = aiclient.config(
+    #   config_value = aiclient.config(ai_config_key, context, default, {'myUserVariable': "Testing Variable"})
+    config_value = aiclient.config(
         ai_config_key,
         context,
         variables={'myUserVariable': "Testing Variable"}
@@ -121,7 +121,7 @@ def main():
         messages.append({'role': 'user', 'content': USER_INPUT})
 
         # Track the LangChain completion with LaunchDarkly metrics
-        completion = track_langchain_metrics(tracker, lambda: llm.invoke(messages))
+        completion = track_langchain_metrics(config_value.tracker, lambda: llm.invoke(messages))
         ai_response = completion.content
 
         # Add the AI response to the conversation history.

--- a/examples/openai_example.py
+++ b/examples/openai_example.py
@@ -2,7 +2,7 @@ import os
 import ldclient
 from ldclient import Context
 from ldclient.config import Config
-from ldai.client import LDAIClient, AIConfig, ModelConfig, ProviderConfig, LDMessage
+from ldai.client import LDAIClient, AICompletionConfigDefault, ModelConfig, ProviderConfig, LDMessage
 from openai import OpenAI
 
 openai_client = OpenAI()
@@ -44,14 +44,14 @@ def main():
     # Pass a default for improved resiliency when the AI config is unavailable
     # or LaunchDarkly is unreachable; omit for a disabled default.
     # Example:
-    #   default = AIConfig(
+    #   default = AICompletionConfigDefault(
     #       enabled=True,
     #       model=ModelConfig(name='gpt-4'),
     #       provider=ProviderConfig(name='openai'),
     #       messages=[LDMessage(role='system', content='You are a helpful assistant.')],
     #   )
-    #   config_value, tracker = aiclient.config(ai_config_key, context, default, {'myUserVariable': "Testing Variable"})
-    config_value, tracker = aiclient.config(
+    #   config_value = aiclient.config(ai_config_key, context, default, {'myUserVariable': "Testing Variable"})
+    config_value = aiclient.config(
         ai_config_key,
         context,
         variables={'myUserVariable': "Testing Variable"}
@@ -69,7 +69,7 @@ def main():
     messages.append({'role': 'user', 'content': USER_INPUT})
 
     # Track the OpenAI completion with LaunchDarkly metrics
-    completion = tracker.track_openai_metrics(
+    completion = config_value.tracker.track_openai_metrics(
         lambda:
             openai_client.chat.completions.create(
                 model=config_value.model.name,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ direct-judge-example = 'examples.direct_judge_example:main'
 python = "^3.10"
 launchdarkly-server-sdk-ai = "^0.16.0"
 launchdarkly-server-sdk-ai-langchain = "^0.3.0"
-launchdarkly-server-sdk-ai-openai = "^0.1.0"
+launchdarkly-server-sdk-ai-openai = "^0.2.0"
 launchdarkly-observability = { version = ">=0.1.0", optional = true }
 
 boto3 = { version = ">=0.2.0", optional = true }


### PR DESCRIPTION
## Summary

Bumps `launchdarkly-server-sdk-ai-openai` from `^0.1.0` (which resolves to `>=0.1.0, <0.2.0`) to `^0.2.0` (which resolves to `>=0.2.0, <0.3.0`), picking up the latest release.

### Updates since last revision

The 0.1→0.2 bump introduced breaking API changes. A second commit updates the affected example scripts:

- **`AIConfig` → `AICompletionConfigDefault`** — The class used for specifying defaults was renamed.
- **`aiclient.config()` return value changed** — Previously returned a `(config_value, tracker)` tuple; now returns a single `AICompletionConfig` object with `tracker` as an attribute.
- **Tracker access** — Changed from `tracker.track_*()` to `config_value.tracker.track_*()`.

**Files updated:** `openai_example.py`, `langchain_example.py`, `bedrock_example.py`, `gemini_example.py` (imports, config call, and tracker access in each).

**Files NOT modified** (already using the new API on `main`): `chat_judge_example.py`, `chat_observability_example.py`, `direct_judge_example.py`, `langgraph_agent_example.py`, `langgraph_multi_agent_example.py`.

## Review & Testing Checklist for Human

- [ ] Verify the four updated examples use the new `AICompletionConfigDefault` / `config_value.tracker` pattern correctly — the migration was based on module introspection, not official migration docs.
- [ ] Run `poetry install -E openai && poetry run openai-example` with valid `LAUNCHDARKLY_SDK_KEY` and `OPENAI_API_KEY` to confirm the OpenAI example works end-to-end. (SDK initialization was tested successfully, but no actual LLM call was made during automated testing.)
- [ ] Spot-check at least one other provider example (e.g. `bedrock-example` or `gemini-example`) to confirm the tracker access pattern works at runtime.
- [ ] Confirm the five unmodified examples (`chat_judge_example`, `chat_observability_example`, `direct_judge_example`, `langgraph_agent_example`, `langgraph_multi_agent_example`) still work — they were already on the new API and were left untouched.

### Notes

- `poetry.lock` is in `.gitignore` for this repo, so no lock file update is included.
- The other AI SDK dependencies (`launchdarkly-server-sdk-ai ^0.16.0`, `launchdarkly-server-sdk-ai-langchain ^0.3.0`) already cover their respective latest releases and were left unchanged.

Link to Devin session: https://app.devin.ai/sessions/b0ebe99ff1ec4b09918d6399ac196ee1
Requested by: @kinyoklion