### PR TITLE
chore: update LaunchDarkly AI SDK and langchain dependencies to latest versions

### DIFF
--- a/examples/langchain_example.py
+++ b/examples/langchain_example.py
@@ -4,7 +4,7 @@ import ldclient
 from ldclient import Context
 from ldclient.config import Config
 from ldai.client import LDAIClient
-from ldai_langchain import LangChainProvider
+from ldai_langchain import get_ai_metrics_from_response
 from langchain.chat_models import init_chat_model
 
 # Set sdk_key to your LaunchDarkly SDK key.
@@ -89,7 +89,7 @@ async def async_main():
         # Track the LangChain completion with LaunchDarkly metrics using the LD LangChain provider's extractor
         completion = await tracker.track_metrics_of(
             lambda: llm.ainvoke(messages),
-            LangChainProvider.get_ai_metrics_from_response,
+            get_ai_metrics_from_response,
         )
         ai_response = completion.content
 

--- a/examples/langgraph_agent_example.py
+++ b/examples/langgraph_agent_example.py
@@ -5,7 +5,7 @@ from ldclient import Context
 from ldclient.config import Config
 from ldai.client import LDAIClient
 from ldai.tracker import TokenUsage
-from ldai_langchain import LangChainProvider
+from ldai_langchain import get_ai_metrics_from_response
 from langchain.chat_models import init_chat_model
 from langgraph.prebuilt import create_react_agent
 
@@ -36,7 +36,7 @@ def track_langgraph_metrics(tracker, func):
         total_tokens = 0
         if "messages" in result:
             for message in result["messages"]:
-                metrics = LangChainProvider.get_ai_metrics_from_response(message)
+                metrics = get_ai_metrics_from_response(message)
                 if metrics.usage:
                     total_input_tokens += metrics.usage.input
                     total_output_tokens += metrics.usage.output

--- a/examples/langgraph_multi_agent_example.py
+++ b/examples/langgraph_multi_agent_example.py
@@ -4,7 +4,7 @@ from ldclient import Context
 from ldclient.config import Config
 from ldai.client import LDAIClient
 from ldai.tracker import TokenUsage
-from ldai_langchain import LangChainProvider
+from ldai_langchain import get_ai_metrics_from_response
 from langchain.chat_models import init_chat_model
 from langgraph.prebuilt import create_react_agent
 from langgraph.graph import StateGraph, END
@@ -47,7 +47,7 @@ def track_langgraph_metrics(tracker, func, prev_message_count=0):
         if "messages" in result:
             new_messages = result["messages"][prev_message_count:]
             for message in new_messages:
-                metrics = LangChainProvider.get_ai_metrics_from_response(message)
+                metrics = get_ai_metrics_from_response(message)
                 if metrics.usage:
                     total_input_tokens += metrics.usage.input
                     total_output_tokens += metrics.usage.output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,20 +20,20 @@ direct-judge-example = 'examples.direct_judge_example:main'
 
 [tool.poetry.dependencies]
 python = "^3.10"
-launchdarkly-server-sdk-ai = "^0.16.1"
-launchdarkly-server-sdk-ai-langchain = "^0.3.2"
-launchdarkly-server-sdk-ai-openai = "^0.2.1"
+launchdarkly-server-sdk-ai = "^0.17.0"
+launchdarkly-server-sdk-ai-langchain = "^0.4.0"
+launchdarkly-server-sdk-ai-openai = "^0.3.0"
 launchdarkly-observability = { version = ">=0.1.0", optional = true }
 
 boto3 = { version = ">=0.2.0", optional = true }
 openai = { version = ">=0.2.0", optional = true }
 google-genai = { version = "^1.30.0", optional = true }
-langchain = {version = "^0.3.0", optional = true}
-langchain-aws = {version = "^0.2.30", optional = true}
-langchain-core = {version = "^0.3.0", optional = true}
-langchain-google-genai = {version = "^2.1.9", optional = true}
-langchain-openai = {version = "^0.3.30", optional = true}
-langgraph = {version = "^0.2.0", optional = true}
+langchain = {version = "^1.0.0", optional = true}
+langchain-aws = {version = "^1.0.0", optional = true}
+langchain-core = {version = "^1.0.0", optional = true}
+langchain-google-genai = {version = "^4.0.0", optional = true}
+langchain-openai = {version = "^1.0.0", optional = true}
+langgraph = {version = "^1.0.0", optional = true}
 
 [tool.poetry.extras]
 bedrock = ["boto3"]


### PR DESCRIPTION
## Summary

Updates LaunchDarkly AI SDK dependencies and the langchain ecosystem to their latest versions. The `ldai_langchain` 0.4.0 release removed the `LangChainProvider` class in favor of top-level helper functions, so the three langchain-based examples are updated accordingly.

**Dependency changes in `pyproject.toml`:**

| Package | Old | New |
|---|---|---|
| `launchdarkly-server-sdk-ai` | ^0.16.1 | ^0.17.0 |
| `launchdarkly-server-sdk-ai-langchain` | ^0.3.2 | ^0.4.0 |
| `launchdarkly-server-sdk-ai-openai` | ^0.2.1 | ^0.3.0 |
| `langchain` | ^0.3.0 | ^1.0.0 |
| `langchain-core` | ^0.3.0 | ^1.0.0 |
| `langchain-aws` | ^0.2.30 | ^1.0.0 |
| `langchain-openai` | ^0.3.30 | ^1.0.0 |
| `langchain-google-genai` | ^2.1.9 | ^4.0.0 |
| `langgraph` | ^0.2.0 | ^1.0.0 |

**Code changes:** `LangChainProvider.get_ai_metrics_from_response` → `get_ai_metrics_from_response` (now a top-level import from `ldai_langchain`) in `langchain_example.py`, `langgraph_agent_example.py`, and `langgraph_multi_agent_example.py`.

## Review & Testing Checklist for Human

- [ ] Verify the langchain 0.x → 1.x migration doesn't break other APIs used in the examples (e.g., `init_chat_model`, message dict format, `ainvoke`). Only the `LangChainProvider` import was updated — other langchain usage was left as-is.
- [ ] Confirm `langchain-google-genai` ^4.0.0 is correct — this skips the 3.x line. Check that the `gemini_example.py` still works with this version.
- [ ] Verify `poetry.lock` is either committed or intentionally gitignored. It is not included in this diff.
- [ ] Run at least one example end-to-end (e.g., `poetry run openai-example` or `poetry run langchain-example`) to confirm the updated SDKs work with a real LaunchDarkly AI config.

### Notes
- The non-langchain examples (`openai_example.py`, `bedrock_example.py`, `gemini_example.py`, `chat_judge_example.py`, `chat_observability_example.py`, `direct_judge_example.py`) were not modified. Their imports were verified to still resolve, but they were not tested end-to-end.
- The langchain ecosystem bump from 0.x to 1.x was required because `ldai_langchain` 0.4.0 itself depends on `langchain >=1.0.0`.

Link to Devin session: https://app.devin.ai/sessions/c8cf47d46e3f464290a65b6c05862c86
Requested by: @kinyoklion