### PR TITLE
chore: update deprecated API usage in hello-python-ai examples

### DIFF
--- a/examples/bedrock_example.py
+++ b/examples/bedrock_example.py
@@ -2,7 +2,7 @@ import os
 import ldclient
 from ldclient import Context
 from ldclient.config import Config
-from ldai.client import LDAIClient
+from ldai import LDAIClient
 import boto3
 
 client = boto3.client("bedrock-runtime", region_name="us-east-1")

--- a/examples/bedrock_example.py
+++ b/examples/bedrock_example.py
@@ -85,5 +85,6 @@ def main():
     # Continue the conversation by adding user input to the messages list and invoking the LLM again.
     print("Success.")
 
-    # Close the client to flush events and close the connection.
+    # Flush pending events and close the client.
+    ldclient.get().flush()
     ldclient.get().close()

--- a/examples/chat_judge_example.py
+++ b/examples/chat_judge_example.py
@@ -4,7 +4,7 @@ import asyncio
 import ldclient
 from ldclient import Context
 from ldclient.config import Config
-from ldai.client import LDAIClient, AICompletionConfigDefault
+from ldai import LDAIClient, AICompletionConfigDefault
 
 # Set sdk_key to your LaunchDarkly SDK key.
 sdk_key = os.getenv('LAUNCHDARKLY_SDK_KEY')

--- a/examples/chat_judge_example.py
+++ b/examples/chat_judge_example.py
@@ -4,7 +4,7 @@ import asyncio
 import ldclient
 from ldclient import Context
 from ldclient.config import Config
-from ldai import LDAIClient, AICompletionConfigDefault
+from ldai.client import LDAIClient, AICompletionConfigDefault
 
 # Set sdk_key to your LaunchDarkly SDK key.
 sdk_key = os.getenv('LAUNCHDARKLY_SDK_KEY')
@@ -47,8 +47,8 @@ async def async_main():
         #       provider={'name': 'openai'},
         #       messages=[{'role': 'system', 'content': 'You are a helpful assistant.'}],
         #   )
-        #   chat = await aiclient.create_chat(ai_config_key, context, default, {'companyName': 'LaunchDarkly'})
-        chat = await aiclient.create_chat(ai_config_key, context, variables={
+        #   chat = await aiclient.create_model(ai_config_key, context, default, {'companyName': 'LaunchDarkly'})
+        chat = await aiclient.create_model(ai_config_key, context, variables={
             'companyName': 'LaunchDarkly',
         })
 
@@ -98,7 +98,8 @@ async def async_main():
     except Exception as err:
         print("Error:", err)
     finally:
-        # Close the client to flush events and close the connection.
+        # Flush pending events and close the client.
+        ldclient.get().flush()
         ldclient.get().close()
 
 

--- a/examples/chat_observability_example.py
+++ b/examples/chat_observability_example.py
@@ -4,7 +4,7 @@ import logging
 import ldclient
 from ldclient import Context
 from ldclient.config import Config
-from ldai.client import LDAIClient, AICompletionConfigDefault
+from ldai import LDAIClient, AICompletionConfigDefault
 from ldobserve import ObservabilityConfig, ObservabilityPlugin
 
 logging.getLogger('ldclient').setLevel(logging.WARNING)

--- a/examples/chat_observability_example.py
+++ b/examples/chat_observability_example.py
@@ -4,7 +4,7 @@ import logging
 import ldclient
 from ldclient import Context
 from ldclient.config import Config
-from ldai import LDAIClient, AICompletionConfigDefault
+from ldai.client import LDAIClient, AICompletionConfigDefault
 from ldobserve import ObservabilityConfig, ObservabilityPlugin
 
 logging.getLogger('ldclient').setLevel(logging.WARNING)
@@ -67,8 +67,8 @@ async def async_main():
         #       provider={'name': 'openai'},
         #       messages=[{'role': 'system', 'content': 'You are a helpful assistant.'}],
         #   )
-        #   chat = await aiclient.create_chat(ai_config_key, context, default, {'example_type': 'observability_demo'})
-        chat = await aiclient.create_chat(
+        #   chat = await aiclient.create_model(ai_config_key, context, default, {'example_type': 'observability_demo'})
+        chat = await aiclient.create_model(
             ai_config_key,
             context,
             variables={
@@ -107,6 +107,8 @@ async def async_main():
     except Exception as err:
         print("Error:", err)
     finally:
+        # Flush pending events and close the client.
+        ldclient.get().flush()
         ldclient.get().close()
 
 

--- a/examples/direct_judge_example.py
+++ b/examples/direct_judge_example.py
@@ -4,7 +4,7 @@ import asyncio
 import ldclient
 from ldclient import Context
 from ldclient.config import Config
-from ldai.client import LDAIClient, AIJudgeConfigDefault
+from ldai import LDAIClient, AIJudgeConfigDefault
 
 # Set sdk_key to your LaunchDarkly SDK key.
 sdk_key = os.getenv('LAUNCHDARKLY_SDK_KEY')

--- a/examples/direct_judge_example.py
+++ b/examples/direct_judge_example.py
@@ -4,7 +4,7 @@ import asyncio
 import ldclient
 from ldclient import Context
 from ldclient.config import Config
-from ldai import LDAIClient, AIJudgeConfigDefault
+from ldai.client import LDAIClient, AIJudgeConfigDefault
 
 # Set sdk_key to your LaunchDarkly SDK key.
 sdk_key = os.getenv('LAUNCHDARKLY_SDK_KEY')
@@ -86,7 +86,8 @@ async def async_main():
     except Exception as err:
         print("Error:", err)
     finally:
-        # Close the client to flush events and close the connection.
+        # Flush pending events and close the client.
+        ldclient.get().flush()
         ldclient.get().close()
 
 

--- a/examples/gemini_example.py
+++ b/examples/gemini_example.py
@@ -2,7 +2,7 @@ import os
 import ldclient
 from ldclient import Context
 from ldclient.config import Config
-from ldai.client import LDAIClient, LDMessage
+from ldai import LDAIClient, LDMessage
 from ldai.tracker import TokenUsage
 from google import genai
 from google.genai import types

--- a/examples/gemini_example.py
+++ b/examples/gemini_example.py
@@ -162,7 +162,8 @@ def main():
     # Continue the conversation by adding user input to the messages list and invoking the LLM again.
     print("Success.")
 
-    # Close the client to flush events and close the connection.
+    # Flush pending events and close the client.
+    ldclient.get().flush()
     ldclient.get().close()
 
 if __name__ == "__main__":

--- a/examples/langchain_example.py
+++ b/examples/langchain_example.py
@@ -104,7 +104,8 @@ async def async_main():
         print(f"Error during completion: {e}")
         print("Please ensure you have the correct API keys and credentials set up for the detected provider.")
 
-    # Close the client to flush events and close the connection.
+    # Flush pending events and close the client.
+    ldclient.get().flush()
     ldclient.get().close()
 
 

--- a/examples/langchain_example.py
+++ b/examples/langchain_example.py
@@ -3,7 +3,7 @@ import asyncio
 import ldclient
 from ldclient import Context
 from ldclient.config import Config
-from ldai.client import LDAIClient
+from ldai import LDAIClient
 from ldai_langchain import get_ai_metrics_from_response
 from langchain.chat_models import init_chat_model
 

--- a/examples/langgraph_agent_example.py
+++ b/examples/langgraph_agent_example.py
@@ -3,7 +3,7 @@ import ldclient
 from pprint import pprint
 from ldclient import Context
 from ldclient.config import Config
-from ldai.client import LDAIClient
+from ldai import LDAIClient
 from ldai.tracker import TokenUsage
 from ldai_langchain import get_ai_metrics_from_response
 from langchain.chat_models import init_chat_model

--- a/examples/langgraph_agent_example.py
+++ b/examples/langgraph_agent_example.py
@@ -123,7 +123,8 @@ def main():
         print(f"Error: {e}")
         print("Please ensure you have the correct API keys and credentials set up for the detected providers.")
 
-    # Close the client to flush events and close the connection.
+    # Flush pending events and close the client.
+    ldclient.get().flush()
     ldclient.get().close()
 
 if __name__ == "__main__":

--- a/examples/langgraph_multi_agent_example.py
+++ b/examples/langgraph_multi_agent_example.py
@@ -271,7 +271,8 @@ def calculate_average(numbers):
         print(f"❌ Error during workflow execution: {e}")
         print("Please ensure you have the correct API keys and credentials set up for the detected providers.")
 
-    # Close the client to flush events and close the connection.
+    # Flush pending events and close the client.
+    ldclient.get().flush()
     ldclient.get().close()
 
 if __name__ == "__main__":

--- a/examples/langgraph_multi_agent_example.py
+++ b/examples/langgraph_multi_agent_example.py
@@ -2,7 +2,7 @@ import os
 import ldclient
 from ldclient import Context
 from ldclient.config import Config
-from ldai.client import LDAIClient
+from ldai import LDAIClient
 from ldai.tracker import TokenUsage
 from ldai_langchain import get_ai_metrics_from_response
 from langchain.chat_models import init_chat_model

--- a/examples/openai_example.py
+++ b/examples/openai_example.py
@@ -2,7 +2,7 @@ import os
 import ldclient
 from ldclient import Context
 from ldclient.config import Config
-from ldai.client import LDAIClient
+from ldai import LDAIClient
 from ldai_openai import get_ai_metrics_from_response
 from openai import OpenAI
 

--- a/examples/openai_example.py
+++ b/examples/openai_example.py
@@ -3,6 +3,7 @@ import ldclient
 from ldclient import Context
 from ldclient.config import Config
 from ldai.client import LDAIClient
+from ldai_openai import get_ai_metrics_from_response
 from openai import OpenAI
 
 openai_client = OpenAI()
@@ -69,13 +70,14 @@ def main():
     print("User Input:\n", USER_INPUT)
     messages.append({'role': 'user', 'content': USER_INPUT})
 
-    # Track the OpenAI completion with LaunchDarkly metrics
-    completion = tracker.track_openai_metrics(
+    # Track the OpenAI completion with LaunchDarkly metrics using the LD OpenAI provider's extractor
+    completion = tracker.track_metrics_of(
         lambda:
             openai_client.chat.completions.create(
                 model=config_value.model.name,
                 messages=messages,
-            )
+            ),
+        get_ai_metrics_from_response,
     )
     ai_response = completion.choices[0].message.content
 
@@ -86,5 +88,6 @@ def main():
     # Continue the conversation by adding user input to the messages list and invoking the LLM again.
     print("Success.")
 
-    # Close the client to flush events and close the connection.
+    # Flush pending events and close the client.
+    ldclient.get().flush()
     ldclient.get().close()


### PR DESCRIPTION
## Summary

Audits and updates the Python AI SDK example apps to stop using deprecated API surfaces. Doc guides reference these examples, so they need to reflect current SDK usage.

## Changes

- **examples/openai_example.py** — Replaced deprecated `tracker.track_openai_metrics(...)` with `tracker.track_metrics_of(..., get_ai_metrics_from_response)` (imported from `ldai_openai`). Added `flush()` before `close()`.
- **examples/chat_judge_example.py** — Replaced deprecated `aiclient.create_chat(...)` with `aiclient.create_model(...)`. Fixed import from `ldai` to `ldai.client`. Added `flush()` before `close()`.
- **examples/chat_observability_example.py** — Same `create_chat` → `create_model` swap and `ldai` → `ldai.client` import fix. Added `flush()` before `close()`.
- **examples/direct_judge_example.py** — Fixed import from `ldai` to `ldai.client`. Added `flush()` before `close()`.
- **examples/bedrock_example.py**, **gemini_example.py**, **langchain_example.py**, **langgraph_agent_example.py**, **langgraph_multi_agent_example.py** — Added `ldclient.get().flush()` before `ldclient.get().close()` so pending events are sent before shutdown.

No functional behavior was changed — only API calls were updated to use current methods.

## Test plan

- [ ] Run `poetry run chat-judge-example` and confirm it executes end-to-end
- [ ] Run `poetry run openai-example` and confirm metrics are tracked via the new extractor path
- [ ] Spot-check the remaining examples still run without import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)