### PR TITLE
chore: Align example config keys and env vars with new naming

### DIFF
--- a/features/create_agent/.env.example
+++ b/features/create_agent/.env.example
@@ -1,0 +1,8 @@
+# Your LaunchDarkly server-side SDK key
+LAUNCHDARKLY_SDK_KEY=
+
+# Provider API key(s) for the provider your agent config uses
+OPENAI_API_KEY=
+
+# Optional - defaults to "sample-agent"
+LAUNCHDARKLY_AGENT_KEY=

--- a/features/create_agent/.env.example
+++ b/features/create_agent/.env.example
@@ -4,5 +4,5 @@ LAUNCHDARKLY_SDK_KEY=
 # Provider API key(s) for the provider your agent config uses
 OPENAI_API_KEY=
 
-# Optional - defaults to "sample-agent"
-LAUNCHDARKLY_AGENT_KEY=
+# Override to use a different AI Config
+LAUNCHDARKLY_AGENT_KEY=sample-agent

--- a/features/create_agent/README.md
+++ b/features/create_agent/README.md
@@ -15,12 +15,10 @@ This example demonstrates how to use LaunchDarkly's `create_agent` method, which
 
    - [Create an AI Agent Config](https://launchdarkly.com/docs/home/ai-configs/agents) with a model and agent instructions. Default key: `sample-agent`.
 
-1. Create a `.env` file in this directory with the following variables:
+1. Copy `.env.example` to `.env` and fill in your keys:
 
-   ```
-   LAUNCHDARKLY_SDK_KEY=your-launchdarkly-sdk-key
-   LAUNCHDARKLY_AGENT_KEY=sample-agent
-   OPENAI_API_KEY=your-openai-api-key
+   ```bash
+   cp .env.example .env
    ```
 
 1. Install the required dependencies:

--- a/features/create_agent/README.md
+++ b/features/create_agent/README.md
@@ -13,13 +13,13 @@ This example demonstrates how to use LaunchDarkly's `create_agent` method, which
 
 1. Create the following config in your LaunchDarkly project. You can use a different key by setting the environment variable in your `.env`.
 
-   - [Create an AI Agent Config](https://launchdarkly.com/docs/home/ai-configs/agents) with a model and agent instructions. Default key: `sample-agent-config`.
+   - [Create an AI Agent Config](https://launchdarkly.com/docs/home/ai-configs/agents) with a model and agent instructions. Default key: `sample-agent`.
 
 1. Create a `.env` file in this directory with the following variables:
 
    ```
    LAUNCHDARKLY_SDK_KEY=your-launchdarkly-sdk-key
-   LAUNCHDARKLY_AGENT_CONFIG_KEY=sample-agent-config
+   LAUNCHDARKLY_AGENT_KEY=sample-agent
    OPENAI_API_KEY=your-openai-api-key
    ```
 

--- a/features/create_agent/create_agent_example.py
+++ b/features/create_agent/create_agent_example.py
@@ -109,6 +109,9 @@ async def async_main():
         else:
             print("\nNo judge evaluations were performed.")
 
+    # For convenience during example debugging, we print the raw error. In
+    # production, sanitize errors before logging — provider responses may
+    # include credentials or other sensitive data.
     except Exception as err:
         print("Error:", err)
     finally:

--- a/features/create_agent/create_agent_example.py
+++ b/features/create_agent/create_agent_example.py
@@ -109,10 +109,8 @@ async def async_main():
         else:
             print("\nNo judge evaluations were performed.")
 
-    # For convenience during example debugging, we print the raw error. In
-    # production, sanitize errors before logging — provider responses may
-    # include credentials or other sensitive data.
     except Exception as err:
+        # In production, sanitize before logging — provider errors may include credentials.
         print("Error:", err)
     finally:
         # Flush pending events and close the client.

--- a/features/create_agent/create_agent_example.py
+++ b/features/create_agent/create_agent_example.py
@@ -17,7 +17,7 @@ logging.getLogger('ldclient').setLevel(logging.WARNING)
 sdk_key = os.getenv('LAUNCHDARKLY_SDK_KEY')
 
 # Set agent_config_key to the AI Agent Config key you want to evaluate.
-agent_config_key = os.getenv('LAUNCHDARKLY_AGENT_CONFIG_KEY', 'sample-agent-config')
+agent_config_key = os.getenv('LAUNCHDARKLY_AGENT_KEY', 'sample-agent')
 
 
 def get_weather(city: str) -> str:

--- a/features/create_agent_graph/.env.example
+++ b/features/create_agent_graph/.env.example
@@ -1,0 +1,8 @@
+# Your LaunchDarkly server-side SDK key
+LAUNCHDARKLY_SDK_KEY=
+
+# Provider API key(s) for the provider(s) your agent graph uses
+OPENAI_API_KEY=
+
+# Optional - defaults to "sample-agent-graph"
+LAUNCHDARKLY_AGENT_GRAPH_KEY=

--- a/features/create_agent_graph/.env.example
+++ b/features/create_agent_graph/.env.example
@@ -4,5 +4,5 @@ LAUNCHDARKLY_SDK_KEY=
 # Provider API key(s) for the provider(s) your agent graph uses
 OPENAI_API_KEY=
 
-# Optional - defaults to "sample-agent-graph"
-LAUNCHDARKLY_AGENT_GRAPH_KEY=
+# Override to use a different AI Config
+LAUNCHDARKLY_AGENT_GRAPH_KEY=sample-agent-graph

--- a/features/create_agent_graph/README.md
+++ b/features/create_agent_graph/README.md
@@ -16,12 +16,10 @@ This example demonstrates how to use LaunchDarkly's `create_agent_graph` method,
    - [Create AI Agent Configs](https://launchdarkly.com/docs/home/ai-configs/agents) for each node in your graph. Configure each with a model and agent instructions. Add tools (e.g. `search_flights`, `search_hotels`, `get_weather`) to the agents that need them.
    - [Create an Agent Graph](https://launchdarkly.com/docs/home/ai-configs/create) that connects your agent configs as nodes with edges defining the workflow. Default key: `sample-agent-graph`.
 
-1. Create a `.env` file in this directory with the following variables:
+1. Copy `.env.example` to `.env` and fill in your keys:
 
-   ```
-   LAUNCHDARKLY_SDK_KEY=your-launchdarkly-sdk-key
-   LAUNCHDARKLY_AGENT_GRAPH_KEY=sample-agent-graph
-   OPENAI_API_KEY=your-openai-api-key
+   ```bash
+   cp .env.example .env
    ```
 
 1. Install the required dependencies:

--- a/features/create_agent_graph/create_agent_graph_example.py
+++ b/features/create_agent_graph/create_agent_graph_example.py
@@ -127,6 +127,9 @@ async def async_main():
                 print(f"  score: {eval_result.score}")
                 print(f"  reasoning: {eval_result.reasoning}")
 
+    # For convenience during example debugging, we print the raw error. In
+    # production, sanitize errors before logging — provider responses may
+    # include credentials or other sensitive data.
     except Exception as err:
         print("Error:", err)
     finally:

--- a/features/create_agent_graph/create_agent_graph_example.py
+++ b/features/create_agent_graph/create_agent_graph_example.py
@@ -127,10 +127,8 @@ async def async_main():
                 print(f"  score: {eval_result.score}")
                 print(f"  reasoning: {eval_result.reasoning}")
 
-    # For convenience during example debugging, we print the raw error. In
-    # production, sanitize errors before logging — provider responses may
-    # include credentials or other sensitive data.
     except Exception as err:
+        # In production, sanitize before logging — provider errors may include credentials.
         print("Error:", err)
     finally:
         # Flush pending events and close the client.

--- a/features/create_judge/.env.example
+++ b/features/create_judge/.env.example
@@ -4,5 +4,5 @@ LAUNCHDARKLY_SDK_KEY=
 # Provider API key(s) for the provider your judge config uses
 OPENAI_API_KEY=
 
-# Optional - defaults to "sample-judge"
-LAUNCHDARKLY_JUDGE_KEY=
+# Override to use a different AI Config
+LAUNCHDARKLY_JUDGE_KEY=sample-judge

--- a/features/create_judge/.env.example
+++ b/features/create_judge/.env.example
@@ -1,0 +1,8 @@
+# Your LaunchDarkly server-side SDK key
+LAUNCHDARKLY_SDK_KEY=
+
+# Provider API key(s) for the provider your judge config uses
+OPENAI_API_KEY=
+
+# Optional - defaults to "sample-judge"
+LAUNCHDARKLY_JUDGE_KEY=

--- a/features/create_judge/README.md
+++ b/features/create_judge/README.md
@@ -13,13 +13,13 @@ This example demonstrates how to use LaunchDarkly's `create_judge` method to eva
 
 1. Create the following config in your LaunchDarkly project. You can use a different key by setting the environment variable in your `.env`.
 
-   - [Create a Judge Config](https://launchdarkly.com/docs/home/ai-configs/judges) for evaluation. Default key: `sample-ai-judge`.
+   - [Create a Judge Config](https://launchdarkly.com/docs/home/ai-configs/judges) for evaluation. Default key: `sample-judge`.
 
 1. Create a `.env` file in this directory with the following variables:
 
    ```
    LAUNCHDARKLY_SDK_KEY=your-launchdarkly-sdk-key
-   LAUNCHDARKLY_AI_JUDGE_KEY=sample-ai-judge
+   LAUNCHDARKLY_JUDGE_KEY=sample-judge
    OPENAI_API_KEY=your-openai-api-key
    ```
 

--- a/features/create_judge/README.md
+++ b/features/create_judge/README.md
@@ -15,12 +15,10 @@ This example demonstrates how to use LaunchDarkly's `create_judge` method to eva
 
    - [Create a Judge Config](https://launchdarkly.com/docs/home/ai-configs/judges) for evaluation. Default key: `sample-judge`.
 
-1. Create a `.env` file in this directory with the following variables:
+1. Copy `.env.example` to `.env` and fill in your keys:
 
-   ```
-   LAUNCHDARKLY_SDK_KEY=your-launchdarkly-sdk-key
-   LAUNCHDARKLY_JUDGE_KEY=sample-judge
-   OPENAI_API_KEY=your-openai-api-key
+   ```bash
+   cp .env.example .env
    ```
 
 1. Install the required dependencies:

--- a/features/create_judge/create_judge_example.py
+++ b/features/create_judge/create_judge_example.py
@@ -94,6 +94,9 @@ async def async_main():
             print(f"  reasoning: {judge_result.reasoning}")
 
         print("\nDone!")
+    # For convenience during example debugging, we print the raw error. In
+    # production, sanitize errors before logging — provider responses may
+    # include credentials or other sensitive data.
     except Exception as err:
         print("Error:", err)
     finally:

--- a/features/create_judge/create_judge_example.py
+++ b/features/create_judge/create_judge_example.py
@@ -17,7 +17,7 @@ logging.getLogger('ldclient').setLevel(logging.WARNING)
 sdk_key = os.getenv('LAUNCHDARKLY_SDK_KEY')
 
 # Set judge_key to the Judge key you want to use.
-judge_key = os.getenv('LAUNCHDARKLY_AI_JUDGE_KEY', 'sample-ai-judge')
+judge_key = os.getenv('LAUNCHDARKLY_JUDGE_KEY', 'sample-judge')
 
 
 async def async_main():

--- a/features/create_judge/create_judge_example.py
+++ b/features/create_judge/create_judge_example.py
@@ -94,10 +94,8 @@ async def async_main():
             print(f"  reasoning: {judge_result.reasoning}")
 
         print("\nDone!")
-    # For convenience during example debugging, we print the raw error. In
-    # production, sanitize errors before logging — provider responses may
-    # include credentials or other sensitive data.
     except Exception as err:
+        # In production, sanitize before logging — provider errors may include credentials.
         print("Error:", err)
     finally:
         # Flush pending events and close the client.

--- a/features/create_model/.env.example
+++ b/features/create_model/.env.example
@@ -4,5 +4,5 @@ LAUNCHDARKLY_SDK_KEY=
 # Provider API key(s) for the provider your AI config uses
 OPENAI_API_KEY=
 
-# Optional - defaults to "sample-completion"
-LAUNCHDARKLY_COMPLETION_KEY=
+# Override to use a different AI Config
+LAUNCHDARKLY_COMPLETION_KEY=sample-completion

--- a/features/create_model/.env.example
+++ b/features/create_model/.env.example
@@ -1,0 +1,8 @@
+# Your LaunchDarkly server-side SDK key
+LAUNCHDARKLY_SDK_KEY=
+
+# Provider API key(s) for the provider your AI config uses
+OPENAI_API_KEY=
+
+# Optional - defaults to "sample-completion"
+LAUNCHDARKLY_COMPLETION_KEY=

--- a/features/create_model/README.md
+++ b/features/create_model/README.md
@@ -15,12 +15,10 @@ This example demonstrates how to use LaunchDarkly's `create_model` method, which
 
    - [Create an AI Config](https://launchdarkly.com/docs/home/ai-configs/create) with a model and system message. Default key: `sample-completion`.
 
-1. Create a `.env` file in this directory with the following variables:
+1. Copy `.env.example` to `.env` and fill in your keys:
 
-   ```
-   LAUNCHDARKLY_SDK_KEY=your-launchdarkly-sdk-key
-   LAUNCHDARKLY_COMPLETION_KEY=sample-completion
-   OPENAI_API_KEY=your-openai-api-key
+   ```bash
+   cp .env.example .env
    ```
 
 1. Install the required dependencies:

--- a/features/create_model/README.md
+++ b/features/create_model/README.md
@@ -13,13 +13,13 @@ This example demonstrates how to use LaunchDarkly's `create_model` method, which
 
 1. Create the following config in your LaunchDarkly project. You can use a different key by setting the environment variable in your `.env`.
 
-   - [Create an AI Config](https://launchdarkly.com/docs/home/ai-configs/create) with a model and system message. Default key: `sample-completion-config`.
+   - [Create an AI Config](https://launchdarkly.com/docs/home/ai-configs/create) with a model and system message. Default key: `sample-completion`.
 
 1. Create a `.env` file in this directory with the following variables:
 
    ```
    LAUNCHDARKLY_SDK_KEY=your-launchdarkly-sdk-key
-   LAUNCHDARKLY_AI_CONFIG_KEY=sample-completion-config
+   LAUNCHDARKLY_COMPLETION_KEY=sample-completion
    OPENAI_API_KEY=your-openai-api-key
    ```
 

--- a/features/create_model/create_model_example.py
+++ b/features/create_model/create_model_example.py
@@ -95,10 +95,8 @@ async def async_main():
         else:
             print("\nNo judge evaluations were performed. Try adding a judge to the AI config to see results.")
 
-    # For convenience during example debugging, we print the raw error. In
-    # production, sanitize errors before logging — provider responses may
-    # include credentials or other sensitive data.
     except Exception as err:
+        # In production, sanitize before logging — provider errors may include credentials.
         print("Error:", err)
     finally:
         # Flush pending events and close the client.

--- a/features/create_model/create_model_example.py
+++ b/features/create_model/create_model_example.py
@@ -95,6 +95,9 @@ async def async_main():
         else:
             print("\nNo judge evaluations were performed. Try adding a judge to the AI config to see results.")
 
+    # For convenience during example debugging, we print the raw error. In
+    # production, sanitize errors before logging — provider responses may
+    # include credentials or other sensitive data.
     except Exception as err:
         print("Error:", err)
     finally:

--- a/features/create_model/create_model_example.py
+++ b/features/create_model/create_model_example.py
@@ -17,7 +17,7 @@ logging.getLogger('ldclient').setLevel(logging.WARNING)
 sdk_key = os.getenv('LAUNCHDARKLY_SDK_KEY')
 
 # Set config_key to the AI Config key you want to evaluate.
-ai_config_key = os.getenv('LAUNCHDARKLY_AI_CONFIG_KEY', 'sample-completion-config')
+ai_config_key = os.getenv('LAUNCHDARKLY_COMPLETION_KEY', 'sample-completion')
 
 
 async def async_main():

--- a/getting_started/bedrock/converse/.env.example
+++ b/getting_started/bedrock/converse/.env.example
@@ -5,8 +5,8 @@ LAUNCHDARKLY_SDK_KEY=
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 
-# Optional - defaults to "us-east-1"
-AWS_DEFAULT_REGION=
+# Override to use a different AWS region
+AWS_DEFAULT_REGION=us-east-1
 
 # Override to use a different AI Config
 LAUNCHDARKLY_COMPLETION_KEY=sample-completion

--- a/getting_started/bedrock/converse/.env.example
+++ b/getting_started/bedrock/converse/.env.example
@@ -1,0 +1,12 @@
+# Your LaunchDarkly server-side SDK key
+LAUNCHDARKLY_SDK_KEY=
+
+# Your AWS credentials for Bedrock access
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+
+# Optional - defaults to "us-east-1"
+AWS_DEFAULT_REGION=
+
+# Optional - defaults to "sample-completion"
+LAUNCHDARKLY_COMPLETION_KEY=

--- a/getting_started/bedrock/converse/.env.example
+++ b/getting_started/bedrock/converse/.env.example
@@ -8,5 +8,5 @@ AWS_SECRET_ACCESS_KEY=
 # Optional - defaults to "us-east-1"
 AWS_DEFAULT_REGION=
 
-# Optional - defaults to "sample-completion"
-LAUNCHDARKLY_COMPLETION_KEY=
+# Override to use a different AI Config
+LAUNCHDARKLY_COMPLETION_KEY=sample-completion

--- a/getting_started/bedrock/converse/README.md
+++ b/getting_started/bedrock/converse/README.md
@@ -13,16 +13,16 @@ This example demonstrates how to use LaunchDarkly's AI Config with the AWS Bedro
 
 1. Create the following config in your LaunchDarkly project. You can use a different key by setting the environment variable in your `.env`.
 
-   - [Create an AI Config](https://launchdarkly.com/docs/home/ai-configs/create) with a Bedrock model and a system message. Default key: `sample-completion-config`.
+   - [Create an AI Config](https://launchdarkly.com/docs/home/ai-configs/create) with a Bedrock model and a system message. Default key: `sample-completion`.
 
 1. Create a `.env` file in this directory with the following variables:
 
    ```
    LAUNCHDARKLY_SDK_KEY=your-launchdarkly-sdk-key
-   LAUNCHDARKLY_AI_CONFIG_KEY=sample-completion-config
+   LAUNCHDARKLY_COMPLETION_KEY=sample-completion
    ```
 
-   > `LAUNCHDARKLY_AI_CONFIG_KEY` defaults to `sample-completion-config` if not set.
+   > `LAUNCHDARKLY_COMPLETION_KEY` defaults to `sample-completion` if not set.
 
 1. Ensure your AWS credentials can be [auto-detected by the `boto3` library](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html). You can set them in your `.env` file:
 

--- a/getting_started/bedrock/converse/README.md
+++ b/getting_started/bedrock/converse/README.md
@@ -15,24 +15,15 @@ This example demonstrates how to use LaunchDarkly's AI Config with the AWS Bedro
 
    - [Create an AI Config](https://launchdarkly.com/docs/home/ai-configs/create) with a Bedrock model and a system message. Default key: `sample-completion`.
 
-1. Create a `.env` file in this directory with the following variables:
+1. Copy `.env.example` to `.env` and fill in your keys:
 
-   ```
-   LAUNCHDARKLY_SDK_KEY=your-launchdarkly-sdk-key
-   LAUNCHDARKLY_COMPLETION_KEY=sample-completion
-   ```
-
-   > `LAUNCHDARKLY_COMPLETION_KEY` defaults to `sample-completion` if not set.
-
-1. Ensure your AWS credentials can be [auto-detected by the `boto3` library](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html). You can set them in your `.env` file:
-
-   ```
-   AWS_ACCESS_KEY_ID=your-access-key-id
-   AWS_SECRET_ACCESS_KEY=your-secret-access-key
-   AWS_DEFAULT_REGION=us-east-1
+   ```bash
+   cp .env.example .env
    ```
 
-   Other options include role providers or shared credential files.
+   `LAUNCHDARKLY_COMPLETION_KEY` defaults to `sample-completion` if not set.
+
+   Ensure your AWS credentials can be [auto-detected by the `boto3` library](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html). Setting them in `.env` is one option; role providers or shared credential files are also supported.
 
 1. Install the required dependencies:
 

--- a/getting_started/bedrock/converse/bedrock_example.py
+++ b/getting_started/bedrock/converse/bedrock_example.py
@@ -40,14 +40,14 @@ def get_bedrock_metrics(response):
 sdk_key = os.getenv('LAUNCHDARKLY_SDK_KEY')
 
 # Set config_key to the AI Config key you want to evaluate.
-ai_config_key = os.getenv('LAUNCHDARKLY_AI_CONFIG_KEY', 'sample-completion-config')
+ai_config_key = os.getenv('LAUNCHDARKLY_COMPLETION_KEY', 'sample-completion')
 
 def main():
     if not sdk_key:
         print("*** Please set the LAUNCHDARKLY_SDK_KEY env first")
         exit()
     if not ai_config_key:
-        print("*** Please set the LAUNCHDARKLY_AI_CONFIG_KEY env first")
+        print("*** Please set the LAUNCHDARKLY_COMPLETION_KEY env first")
         exit()
 
     ldclient.set_config(Config(sdk_key, plugins=[

--- a/getting_started/gemini/generate_content/.env.example
+++ b/getting_started/gemini/generate_content/.env.example
@@ -1,0 +1,8 @@
+# Your LaunchDarkly server-side SDK key
+LAUNCHDARKLY_SDK_KEY=
+
+# Your Google API key
+GOOGLE_API_KEY=
+
+# Optional - defaults to "sample-completion"
+LAUNCHDARKLY_COMPLETION_KEY=

--- a/getting_started/gemini/generate_content/.env.example
+++ b/getting_started/gemini/generate_content/.env.example
@@ -4,5 +4,5 @@ LAUNCHDARKLY_SDK_KEY=
 # Your Google API key
 GOOGLE_API_KEY=
 
-# Optional - defaults to "sample-completion"
-LAUNCHDARKLY_COMPLETION_KEY=
+# Override to use a different AI Config
+LAUNCHDARKLY_COMPLETION_KEY=sample-completion

--- a/getting_started/gemini/generate_content/README.md
+++ b/getting_started/gemini/generate_content/README.md
@@ -15,12 +15,10 @@ This example demonstrates how to use LaunchDarkly's AI Config with the Google Ge
 
    - [Create an AI Config](https://launchdarkly.com/docs/home/ai-configs/create) with a Gemini model (e.g. `gemini-2.0-flash`) and a system message. Default key: `sample-completion`.
 
-1. Create a `.env` file in this directory with the following variables:
+1. Copy `.env.example` to `.env` and fill in your keys:
 
-   ```
-   LAUNCHDARKLY_SDK_KEY=your-launchdarkly-sdk-key
-   LAUNCHDARKLY_COMPLETION_KEY=sample-completion
-   GOOGLE_API_KEY=your-google-api-key
+   ```bash
+   cp .env.example .env
    ```
 
 1. Install the required dependencies:

--- a/getting_started/gemini/generate_content/README.md
+++ b/getting_started/gemini/generate_content/README.md
@@ -13,13 +13,13 @@ This example demonstrates how to use LaunchDarkly's AI Config with the Google Ge
 
 1. Create the following config in your LaunchDarkly project. You can use a different key by setting the environment variable in your `.env`.
 
-   - [Create an AI Config](https://launchdarkly.com/docs/home/ai-configs/create) with a Gemini model (e.g. `gemini-2.0-flash`) and a system message. Default key: `sample-completion-config`.
+   - [Create an AI Config](https://launchdarkly.com/docs/home/ai-configs/create) with a Gemini model (e.g. `gemini-2.0-flash`) and a system message. Default key: `sample-completion`.
 
 1. Create a `.env` file in this directory with the following variables:
 
    ```
    LAUNCHDARKLY_SDK_KEY=your-launchdarkly-sdk-key
-   LAUNCHDARKLY_AI_CONFIG_KEY=sample-completion-config
+   LAUNCHDARKLY_COMPLETION_KEY=sample-completion
    GOOGLE_API_KEY=your-google-api-key
    ```
 

--- a/getting_started/gemini/generate_content/gemini_example.py
+++ b/getting_started/gemini/generate_content/gemini_example.py
@@ -20,7 +20,7 @@ logging.getLogger('ldclient').setLevel(logging.WARNING)
 sdk_key = os.getenv('LAUNCHDARKLY_SDK_KEY')
 
 # Set config_key to the AI Config key you want to evaluate.
-ai_config_key = os.getenv('LAUNCHDARKLY_AI_CONFIG_KEY', 'sample-completion-config')
+ai_config_key = os.getenv('LAUNCHDARKLY_COMPLETION_KEY', 'sample-completion')
 
 # Set Google API key
 google_api_key = os.getenv('GOOGLE_API_KEY')
@@ -93,7 +93,7 @@ def main():
         print("*** Please set the LAUNCHDARKLY_SDK_KEY env first")
         exit()
     if not ai_config_key:
-        print("*** Please set the LAUNCHDARKLY_AI_CONFIG_KEY env first")
+        print("*** Please set the LAUNCHDARKLY_COMPLETION_KEY env first")
         exit()
     if not google_api_key:
         print("*** Please set the GOOGLE_API_KEY env first")

--- a/getting_started/langchain/invoke/.env.example
+++ b/getting_started/langchain/invoke/.env.example
@@ -7,5 +7,5 @@ GOOGLE_API_KEY=
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 
-# Optional - defaults to "sample-completion"
-LAUNCHDARKLY_COMPLETION_KEY=
+# Override to use a different AI Config
+LAUNCHDARKLY_COMPLETION_KEY=sample-completion

--- a/getting_started/langchain/invoke/.env.example
+++ b/getting_started/langchain/invoke/.env.example
@@ -1,0 +1,11 @@
+# Your LaunchDarkly server-side SDK key
+LAUNCHDARKLY_SDK_KEY=
+
+# Provider API keys - fill in the ones for the provider(s) your AI config uses
+OPENAI_API_KEY=
+GOOGLE_API_KEY=
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+
+# Optional - defaults to "sample-completion"
+LAUNCHDARKLY_COMPLETION_KEY=

--- a/getting_started/langchain/invoke/README.md
+++ b/getting_started/langchain/invoke/README.md
@@ -15,20 +15,10 @@ This example demonstrates how to use LaunchDarkly's AI Config with LangChain, su
 
    - [Create an AI Config](https://launchdarkly.com/docs/home/ai-configs/create) with a model and a system message. Default key: `sample-completion`.
 
-1. Create a `.env` file in this directory with the following variables:
+1. Copy `.env.example` to `.env` and fill in your keys (only the provider keys for providers you actually use are required):
 
-   ```
-   LAUNCHDARKLY_SDK_KEY=your-launchdarkly-sdk-key
-   LAUNCHDARKLY_COMPLETION_KEY=sample-completion
-   ```
-
-   Add the API keys for the providers you want to use:
-
-   ```
-   OPENAI_API_KEY=your-openai-api-key
-   GOOGLE_API_KEY=your-google-api-key
-   AWS_ACCESS_KEY_ID=your-access-key-id
-   AWS_SECRET_ACCESS_KEY=your-secret-access-key
+   ```bash
+   cp .env.example .env
    ```
 
 1. Install the required dependencies:

--- a/getting_started/langchain/invoke/README.md
+++ b/getting_started/langchain/invoke/README.md
@@ -13,13 +13,13 @@ This example demonstrates how to use LaunchDarkly's AI Config with LangChain, su
 
 1. Create the following config in your LaunchDarkly project. You can use a different key by setting the environment variable in your `.env`.
 
-   - [Create an AI Config](https://launchdarkly.com/docs/home/ai-configs/create) with a model and a system message. Default key: `sample-completion-config`.
+   - [Create an AI Config](https://launchdarkly.com/docs/home/ai-configs/create) with a model and a system message. Default key: `sample-completion`.
 
 1. Create a `.env` file in this directory with the following variables:
 
    ```
    LAUNCHDARKLY_SDK_KEY=your-launchdarkly-sdk-key
-   LAUNCHDARKLY_AI_CONFIG_KEY=sample-completion-config
+   LAUNCHDARKLY_COMPLETION_KEY=sample-completion
    ```
 
    Add the API keys for the providers you want to use:

--- a/getting_started/langchain/invoke/langchain_example.py
+++ b/getting_started/langchain/invoke/langchain_example.py
@@ -118,10 +118,8 @@ async def async_main():
         if summary.tool_calls:
             print(f"  Tool calls:    {', '.join(summary.tool_calls)}")
 
-    # For convenience during example debugging, we print the raw error. In
-    # production, sanitize errors before logging — provider responses may
-    # include credentials or other sensitive data.
     except Exception as e:
+        # In production, sanitize before logging — provider errors may include credentials.
         print(f"Error during completion: {e}")
         print("Please ensure you have the correct API keys and credentials set up for the detected provider.")
 

--- a/getting_started/langchain/invoke/langchain_example.py
+++ b/getting_started/langchain/invoke/langchain_example.py
@@ -118,6 +118,9 @@ async def async_main():
         if summary.tool_calls:
             print(f"  Tool calls:    {', '.join(summary.tool_calls)}")
 
+    # For convenience during example debugging, we print the raw error. In
+    # production, sanitize errors before logging — provider responses may
+    # include credentials or other sensitive data.
     except Exception as e:
         print(f"Error during completion: {e}")
         print("Please ensure you have the correct API keys and credentials set up for the detected provider.")

--- a/getting_started/langchain/invoke/langchain_example.py
+++ b/getting_started/langchain/invoke/langchain_example.py
@@ -19,7 +19,7 @@ logging.getLogger('ldclient').setLevel(logging.WARNING)
 sdk_key = os.getenv('LAUNCHDARKLY_SDK_KEY')
 
 # Set config_key to the AI Config key you want to evaluate.
-ai_config_key = os.getenv('LAUNCHDARKLY_AI_CONFIG_KEY', 'sample-completion-config')
+ai_config_key = os.getenv('LAUNCHDARKLY_COMPLETION_KEY', 'sample-completion')
 
 def map_provider_to_langchain(provider_name):
     """Map LaunchDarkly provider names to LangChain provider names."""
@@ -35,7 +35,7 @@ async def async_main():
         print("*** Please set the LAUNCHDARKLY_SDK_KEY env first")
         exit()
     if not ai_config_key:
-        print("*** Please set the LAUNCHDARKLY_AI_CONFIG_KEY env first")
+        print("*** Please set the LAUNCHDARKLY_COMPLETION_KEY env first")
         exit()
 
     ldclient.set_config(Config(sdk_key, plugins=[

--- a/getting_started/langgraph/react_agent/.env.example
+++ b/getting_started/langgraph/react_agent/.env.example
@@ -1,0 +1,11 @@
+# Your LaunchDarkly server-side SDK key
+LAUNCHDARKLY_SDK_KEY=
+
+# Provider API keys - fill in the ones for the provider(s) your agent config uses
+OPENAI_API_KEY=
+GOOGLE_API_KEY=
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+
+# Optional - defaults to "sample-agent"
+LAUNCHDARKLY_AGENT_KEY=

--- a/getting_started/langgraph/react_agent/.env.example
+++ b/getting_started/langgraph/react_agent/.env.example
@@ -7,5 +7,5 @@ GOOGLE_API_KEY=
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 
-# Optional - defaults to "sample-agent"
-LAUNCHDARKLY_AGENT_KEY=
+# Override to use a different AI Config
+LAUNCHDARKLY_AGENT_KEY=sample-agent

--- a/getting_started/langgraph/react_agent/README.md
+++ b/getting_started/langgraph/react_agent/README.md
@@ -13,13 +13,13 @@ This example demonstrates how to use LaunchDarkly's AI Config with LangGraph to 
 
 1. Create the following config in your LaunchDarkly project. You can use a different key by setting the environment variable in your `.env`.
 
-   - [Create an AI Agent Config](https://launchdarkly.com/docs/home/ai-configs/agents) with a model and agent instructions. Default key: `sample-agent-config`.
+   - [Create an AI Agent Config](https://launchdarkly.com/docs/home/ai-configs/agents) with a model and agent instructions. Default key: `sample-agent`.
 
 1. Create a `.env` file in this directory with the following variables:
 
    ```
    LAUNCHDARKLY_SDK_KEY=your-launchdarkly-sdk-key
-   LAUNCHDARKLY_AGENT_CONFIG_KEY=sample-agent-config
+   LAUNCHDARKLY_AGENT_KEY=sample-agent
    ```
 
    Add the API keys for the providers you want to use:

--- a/getting_started/langgraph/react_agent/README.md
+++ b/getting_started/langgraph/react_agent/README.md
@@ -15,20 +15,10 @@ This example demonstrates how to use LaunchDarkly's AI Config with LangGraph to 
 
    - [Create an AI Agent Config](https://launchdarkly.com/docs/home/ai-configs/agents) with a model and agent instructions. Default key: `sample-agent`.
 
-1. Create a `.env` file in this directory with the following variables:
+1. Copy `.env.example` to `.env` and fill in your keys (only the provider keys for providers you actually use are required):
 
-   ```
-   LAUNCHDARKLY_SDK_KEY=your-launchdarkly-sdk-key
-   LAUNCHDARKLY_AGENT_KEY=sample-agent
-   ```
-
-   Add the API keys for the providers you want to use:
-
-   ```
-   OPENAI_API_KEY=your-openai-api-key
-   GOOGLE_API_KEY=your-google-api-key
-   AWS_ACCESS_KEY_ID=your-access-key-id
-   AWS_SECRET_ACCESS_KEY=your-secret-access-key
+   ```bash
+   cp .env.example .env
    ```
 
 1. Install the required dependencies:

--- a/getting_started/langgraph/react_agent/langgraph_agent_example.py
+++ b/getting_started/langgraph/react_agent/langgraph_agent_example.py
@@ -20,7 +20,7 @@ logging.getLogger('ldclient').setLevel(logging.WARNING)
 sdk_key = os.getenv('LAUNCHDARKLY_SDK_KEY')
 
 # Set config key for the agent
-agent_config_key = os.getenv('LAUNCHDARKLY_AGENT_CONFIG_KEY', 'sample-agent-config')
+agent_config_key = os.getenv('LAUNCHDARKLY_AGENT_KEY', 'sample-agent')
 
 def map_provider_to_langchain(provider_name):
     """Map LaunchDarkly provider names to LangChain provider names."""

--- a/getting_started/langgraph/react_agent/langgraph_agent_example.py
+++ b/getting_started/langgraph/react_agent/langgraph_agent_example.py
@@ -121,10 +121,8 @@ def main():
         if summary.tool_calls:
             print(f"  Tool calls:    {', '.join(summary.tool_calls)}")
 
-    # For convenience during example debugging, we print the raw error. In
-    # production, sanitize errors before logging — provider responses may
-    # include credentials or other sensitive data.
     except Exception as e:
+        # In production, sanitize before logging — provider errors may include credentials.
         print(f"\nError: {e}")
         print("Please ensure you have the correct API keys and credentials set up for the detected providers.")
 

--- a/getting_started/langgraph/react_agent/langgraph_agent_example.py
+++ b/getting_started/langgraph/react_agent/langgraph_agent_example.py
@@ -121,6 +121,9 @@ def main():
         if summary.tool_calls:
             print(f"  Tool calls:    {', '.join(summary.tool_calls)}")
 
+    # For convenience during example debugging, we print the raw error. In
+    # production, sanitize errors before logging — provider responses may
+    # include credentials or other sensitive data.
     except Exception as e:
         print(f"\nError: {e}")
         print("Please ensure you have the correct API keys and credentials set up for the detected providers.")

--- a/getting_started/langgraph/state_graph/.env.example
+++ b/getting_started/langgraph/state_graph/.env.example
@@ -7,8 +7,8 @@ GOOGLE_API_KEY=
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 
-# Optional - defaults to "code-review-analyzer"
-LAUNCHDARKLY_ANALYZER_KEY=
+# Override to use a different AI Config
+LAUNCHDARKLY_ANALYZER_KEY=code-review-analyzer
 
-# Optional - defaults to "code-review-documentation"
-LAUNCHDARKLY_DOCUMENTATION_KEY=
+# Override to use a different AI Config
+LAUNCHDARKLY_DOCUMENTATION_KEY=code-review-documentation

--- a/getting_started/langgraph/state_graph/.env.example
+++ b/getting_started/langgraph/state_graph/.env.example
@@ -1,0 +1,14 @@
+# Your LaunchDarkly server-side SDK key
+LAUNCHDARKLY_SDK_KEY=
+
+# Provider API keys - fill in the ones for the provider(s) your agent configs use
+OPENAI_API_KEY=
+GOOGLE_API_KEY=
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+
+# Optional - defaults to "code-review-analyzer"
+LAUNCHDARKLY_ANALYZER_KEY=
+
+# Optional - defaults to "code-review-documentation"
+LAUNCHDARKLY_DOCUMENTATION_KEY=

--- a/getting_started/langgraph/state_graph/README.md
+++ b/getting_started/langgraph/state_graph/README.md
@@ -16,21 +16,10 @@ This example demonstrates how to use LaunchDarkly's AI Config with LangGraph to 
    - [Create an AI Agent Config](https://launchdarkly.com/docs/home/ai-configs/agents) for code analysis. Default key: `code-review-analyzer`.
    - [Create an AI Agent Config](https://launchdarkly.com/docs/home/ai-configs/agents) for documentation generation. Default key: `code-review-documentation`.
 
-1. Create a `.env` file in this directory with the following variables:
+1. Copy `.env.example` to `.env` and fill in your keys (only the provider keys for providers you actually use are required):
 
-   ```
-   LAUNCHDARKLY_SDK_KEY=your-launchdarkly-sdk-key
-   LAUNCHDARKLY_ANALYZER_CONFIG_KEY=code-review-analyzer
-   LAUNCHDARKLY_DOCUMENTATION_CONFIG_KEY=code-review-documentation
-   ```
-
-   Add the API keys for the providers you want to use:
-
-   ```
-   OPENAI_API_KEY=your-openai-api-key
-   GOOGLE_API_KEY=your-google-api-key
-   AWS_ACCESS_KEY_ID=your-access-key-id
-   AWS_SECRET_ACCESS_KEY=your-secret-access-key
+   ```bash
+   cp .env.example .env
    ```
 
 1. Install the required dependencies:

--- a/getting_started/langgraph/state_graph/langgraph_multi_agent_example.py
+++ b/getting_started/langgraph/state_graph/langgraph_multi_agent_example.py
@@ -23,8 +23,8 @@ logging.getLogger('ldclient').setLevel(logging.WARNING)
 sdk_key = os.getenv('LAUNCHDARKLY_SDK_KEY')
 
 # Set config keys for the two agents
-analyzer_config_key = os.getenv('LAUNCHDARKLY_ANALYZER_CONFIG_KEY', 'code-review-analyzer')
-documentation_config_key = os.getenv('LAUNCHDARKLY_DOCUMENTATION_CONFIG_KEY', 'code-review-documentation')
+analyzer_config_key = os.getenv('LAUNCHDARKLY_ANALYZER_KEY', 'code-review-analyzer')
+documentation_config_key = os.getenv('LAUNCHDARKLY_DOCUMENTATION_KEY', 'code-review-documentation')
 
 # Custom state class for the code review workflow
 class CodeReviewState(TypedDict):

--- a/getting_started/langgraph/state_graph/langgraph_multi_agent_example.py
+++ b/getting_started/langgraph/state_graph/langgraph_multi_agent_example.py
@@ -147,10 +147,8 @@ def ai_node(
             }
         )
         
-    # For convenience during example debugging, we print the raw error. In
-    # production, sanitize errors before logging — provider responses may
-    # include credentials or other sensitive data.
     except Exception as e:
+        # In production, sanitize before logging — provider errors may include credentials.
         print(f"Error in node for {config_key}: {e}")
         return Command(
             goto=END,
@@ -281,10 +279,8 @@ def calculate_average(numbers):
         print(final_report)
         print("="*80)
         
-    # For convenience during example debugging, we print the raw error. In
-    # production, sanitize errors before logging — provider responses may
-    # include credentials or other sensitive data.
     except Exception as e:
+        # In production, sanitize before logging — provider errors may include credentials.
         print(f"Error during workflow execution: {e}")
         print("Please ensure you have the correct API keys and credentials set up for the detected providers.")
 

--- a/getting_started/langgraph/state_graph/langgraph_multi_agent_example.py
+++ b/getting_started/langgraph/state_graph/langgraph_multi_agent_example.py
@@ -147,6 +147,9 @@ def ai_node(
             }
         )
         
+    # For convenience during example debugging, we print the raw error. In
+    # production, sanitize errors before logging — provider responses may
+    # include credentials or other sensitive data.
     except Exception as e:
         print(f"Error in node for {config_key}: {e}")
         return Command(
@@ -278,6 +281,9 @@ def calculate_average(numbers):
         print(final_report)
         print("="*80)
         
+    # For convenience during example debugging, we print the raw error. In
+    # production, sanitize errors before logging — provider responses may
+    # include credentials or other sensitive data.
     except Exception as e:
         print(f"Error during workflow execution: {e}")
         print("Please ensure you have the correct API keys and credentials set up for the detected providers.")

--- a/getting_started/openai/chat_completions/.env.example
+++ b/getting_started/openai/chat_completions/.env.example
@@ -1,0 +1,8 @@
+# Your LaunchDarkly server-side SDK key
+LAUNCHDARKLY_SDK_KEY=
+
+# Your OpenAI API key
+OPENAI_API_KEY=
+
+# Optional - defaults to "sample-completion"
+LAUNCHDARKLY_COMPLETION_KEY=

--- a/getting_started/openai/chat_completions/.env.example
+++ b/getting_started/openai/chat_completions/.env.example
@@ -4,5 +4,5 @@ LAUNCHDARKLY_SDK_KEY=
 # Your OpenAI API key
 OPENAI_API_KEY=
 
-# Optional - defaults to "sample-completion"
-LAUNCHDARKLY_COMPLETION_KEY=
+# Override to use a different AI Config
+LAUNCHDARKLY_COMPLETION_KEY=sample-completion

--- a/getting_started/openai/chat_completions/README.md
+++ b/getting_started/openai/chat_completions/README.md
@@ -13,13 +13,13 @@ This example demonstrates how to use LaunchDarkly's AI Config with the OpenAI pr
 
 1. Create the following config in your LaunchDarkly project. You can use a different key by setting the environment variable in your `.env`.
 
-   - [Create an AI Config](https://launchdarkly.com/docs/home/ai-configs/create) with an OpenAI model (e.g. `gpt-4`) and a system message. Default key: `sample-completion-config`.
+   - [Create an AI Config](https://launchdarkly.com/docs/home/ai-configs/create) with an OpenAI model (e.g. `gpt-4`) and a system message. Default key: `sample-completion`.
 
 1. Create a `.env` file in this directory with the following variables:
 
    ```
    LAUNCHDARKLY_SDK_KEY=your-launchdarkly-sdk-key
-   LAUNCHDARKLY_AI_CONFIG_KEY=sample-completion-config
+   LAUNCHDARKLY_COMPLETION_KEY=sample-completion
    OPENAI_API_KEY=your-openai-api-key
    ```
 

--- a/getting_started/openai/chat_completions/README.md
+++ b/getting_started/openai/chat_completions/README.md
@@ -15,12 +15,10 @@ This example demonstrates how to use LaunchDarkly's AI Config with the OpenAI pr
 
    - [Create an AI Config](https://launchdarkly.com/docs/home/ai-configs/create) with an OpenAI model (e.g. `gpt-4`) and a system message. Default key: `sample-completion`.
 
-1. Create a `.env` file in this directory with the following variables:
+1. Copy `.env.example` to `.env` and fill in your keys:
 
-   ```
-   LAUNCHDARKLY_SDK_KEY=your-launchdarkly-sdk-key
-   LAUNCHDARKLY_COMPLETION_KEY=sample-completion
-   OPENAI_API_KEY=your-openai-api-key
+   ```bash
+   cp .env.example .env
    ```
 
 1. Install the required dependencies:

--- a/getting_started/openai/chat_completions/openai_example.py
+++ b/getting_started/openai/chat_completions/openai_example.py
@@ -20,7 +20,7 @@ openai_client = OpenAI()
 sdk_key = os.getenv('LAUNCHDARKLY_SDK_KEY')
 
 # Set config_key to the AI Config key you want to evaluate.
-ai_config_key = os.getenv('LAUNCHDARKLY_AI_CONFIG_KEY', 'sample-completion-config')
+ai_config_key = os.getenv('LAUNCHDARKLY_COMPLETION_KEY', 'sample-completion')
 
 
 def main():
@@ -28,7 +28,7 @@ def main():
         print("*** Please set the LAUNCHDARKLY_SDK_KEY env first")
         exit()
     if not ai_config_key:
-        print("*** Please set the LAUNCHDARKLY_AI_CONFIG_KEY env first")
+        print("*** Please set the LAUNCHDARKLY_COMPLETION_KEY env first")
         exit()
 
     ldclient.set_config(Config(sdk_key, plugins=[


### PR DESCRIPTION
## Summary

Back-port of the naming changes landed in js-core PR #1379 (https://github.com/launchdarkly/js-core/pull/1379). Drops the `_CONFIG_KEY` env-var suffix and the trailing `-config` / `-ai-` on the default AI Config keys so the names are consistent and concise across SDKs.

| Old env var | Old default | -> New env var | New default |
|---|---|---|---|
| `LAUNCHDARKLY_AI_CONFIG_KEY` | `sample-completion-config` | `LAUNCHDARKLY_COMPLETION_KEY` | `sample-completion` |
| `LAUNCHDARKLY_AGENT_CONFIG_KEY` | `sample-agent-config` | `LAUNCHDARKLY_AGENT_KEY` | `sample-agent` |
| `LAUNCHDARKLY_AI_JUDGE_KEY` | `sample-ai-judge` | `LAUNCHDARKLY_JUDGE_KEY` | `sample-judge` |
| `LAUNCHDARKLY_ANALYZER_CONFIG_KEY` | `code-review-analyzer` | `LAUNCHDARKLY_ANALYZER_KEY` | _unchanged_ |
| `LAUNCHDARKLY_DOCUMENTATION_CONFIG_KEY` | `code-review-documentation` | `LAUNCHDARKLY_DOCUMENTATION_KEY` | _unchanged_ |

`LAUNCHDARKLY_AGENT_GRAPH_KEY` / `sample-agent-graph` were already aligned and are unchanged.

Also adds a `.env.example` to each of the 10 example directories — the repo uses `python-dotenv` but didn't ship samples. Each `.env.example` lists only the env vars the example actually reads.

## Test plan

- [x] `poetry run openai-example` runs end-to-end against an AI Config and prints the metric summary