### PR TITLE
fix: Use tokens= instead of usage= on LDAIMetrics constructors

### DIFF
--- a/features/create_agent/pyproject.toml
+++ b/features/create_agent/pyproject.toml
@@ -13,7 +13,7 @@ agent = "create_agent_example:main"
 [tool.poetry.dependencies]
 python = "^3.10"
 python-dotenv = ">=1.0.0"
-launchdarkly-server-sdk-ai = ">=0.19.0"
+launchdarkly-server-sdk-ai = ">=0.20.0"
 launchdarkly-observability = ">=0.1.0"
 launchdarkly-server-sdk-ai-openai = {version = ">=0.5.0", extras = ["agents"]}
 launchdarkly-server-sdk-ai-langchain = ">=0.6.0"

--- a/features/create_agent_graph/pyproject.toml
+++ b/features/create_agent_graph/pyproject.toml
@@ -13,7 +13,7 @@ agent-graph = "create_agent_graph_example:main"
 [tool.poetry.dependencies]
 python = "^3.10"
 python-dotenv = ">=1.0.0"
-launchdarkly-server-sdk-ai = ">=0.19.0"
+launchdarkly-server-sdk-ai = ">=0.20.0"
 launchdarkly-observability = ">=0.1.0"
 launchdarkly-server-sdk-ai-openai = {version = ">=0.5.0", extras = ["agents"]}
 launchdarkly-server-sdk-ai-langchain = {version = ">=0.6.0", extras = ["graph"]}

--- a/features/create_judge/pyproject.toml
+++ b/features/create_judge/pyproject.toml
@@ -13,7 +13,7 @@ judge = "create_judge_example:main"
 [tool.poetry.dependencies]
 python = "^3.10"
 python-dotenv = ">=1.0.0"
-launchdarkly-server-sdk-ai = ">=0.19.0"
+launchdarkly-server-sdk-ai = ">=0.20.0"
 launchdarkly-observability = ">=0.1.0"
 launchdarkly-server-sdk-ai-openai = ">=0.5.0"
 launchdarkly-server-sdk-ai-langchain = ">=0.6.0"

--- a/features/create_model/pyproject.toml
+++ b/features/create_model/pyproject.toml
@@ -13,7 +13,7 @@ model = "create_model_example:main"
 [tool.poetry.dependencies]
 python = "^3.10"
 python-dotenv = ">=1.0.0"
-launchdarkly-server-sdk-ai = ">=0.19.0"
+launchdarkly-server-sdk-ai = ">=0.20.0"
 launchdarkly-observability = ">=0.1.0"
 launchdarkly-server-sdk-ai-openai = ">=0.5.0"
 launchdarkly-server-sdk-ai-langchain = ">=0.6.0"

--- a/getting_started/bedrock/converse/bedrock_example.py
+++ b/getting_started/bedrock/converse/bedrock_example.py
@@ -34,7 +34,7 @@ def get_bedrock_metrics(response):
 
     duration_ms = response.get("metrics", {}).get("latencyMs")
 
-    return LDAIMetrics(success=success, usage=usage, duration_ms=duration_ms)
+    return LDAIMetrics(success=success, tokens=usage, duration_ms=duration_ms)
 
 # Set sdk_key to your LaunchDarkly SDK key.
 sdk_key = os.getenv('LAUNCHDARKLY_SDK_KEY')

--- a/getting_started/bedrock/converse/pyproject.toml
+++ b/getting_started/bedrock/converse/pyproject.toml
@@ -13,7 +13,7 @@ bedrock = "bedrock_example:main"
 [tool.poetry.dependencies]
 python = "^3.10"
 python-dotenv = ">=1.0.0"
-launchdarkly-server-sdk-ai = ">=0.19.0"
+launchdarkly-server-sdk-ai = ">=0.20.0"
 launchdarkly-observability = ">=0.1.0"
 boto3 = ">=0.2.0"
 

--- a/getting_started/gemini/generate_content/pyproject.toml
+++ b/getting_started/gemini/generate_content/pyproject.toml
@@ -13,7 +13,7 @@ gemini = "gemini_example:main"
 [tool.poetry.dependencies]
 python = "^3.10"
 python-dotenv = ">=1.0.0"
-launchdarkly-server-sdk-ai = ">=0.19.0"
+launchdarkly-server-sdk-ai = ">=0.20.0"
 launchdarkly-observability = ">=0.1.0"
 google-genai = "^1.30.0"
 

--- a/getting_started/langchain/invoke/pyproject.toml
+++ b/getting_started/langchain/invoke/pyproject.toml
@@ -13,7 +13,7 @@ langchain = "langchain_example:main"
 [tool.poetry.dependencies]
 python = "^3.10"
 python-dotenv = ">=1.0.0"
-launchdarkly-server-sdk-ai = ">=0.19.0"
+launchdarkly-server-sdk-ai = ">=0.20.0"
 launchdarkly-observability = ">=0.1.0"
 launchdarkly-server-sdk-ai-langchain = ">=0.6.0"
 langchain = "^1.0.0"

--- a/getting_started/langgraph/react_agent/langgraph_agent_example.py
+++ b/getting_started/langgraph/react_agent/langgraph_agent_example.py
@@ -33,7 +33,7 @@ def map_provider_to_langchain(provider_name):
 def get_langgraph_metrics(response):
     """Extract aggregated metrics from a LangGraph agent response."""
     messages = response.get("messages", [])
-    return LDAIMetrics(success=True, usage=sum_token_usage_from_messages(messages))
+    return LDAIMetrics(success=True, tokens=sum_token_usage_from_messages(messages))
 
 def get_weather(city: str) -> str:
     """Get the weather for a given city."""

--- a/getting_started/langgraph/react_agent/pyproject.toml
+++ b/getting_started/langgraph/react_agent/pyproject.toml
@@ -13,7 +13,7 @@ agent = "langgraph_agent_example:main"
 [tool.poetry.dependencies]
 python = "^3.10"
 python-dotenv = ">=1.0.0"
-launchdarkly-server-sdk-ai = ">=0.19.0"
+launchdarkly-server-sdk-ai = ">=0.20.0"
 launchdarkly-observability = ">=0.1.0"
 launchdarkly-server-sdk-ai-langchain = ">=0.6.0"
 langchain = "^1.0.0"

--- a/getting_started/langgraph/state_graph/pyproject.toml
+++ b/getting_started/langgraph/state_graph/pyproject.toml
@@ -13,7 +13,7 @@ agent-graph = "langgraph_multi_agent_example:main"
 [tool.poetry.dependencies]
 python = "^3.10"
 python-dotenv = ">=1.0.0"
-launchdarkly-server-sdk-ai = ">=0.19.0"
+launchdarkly-server-sdk-ai = ">=0.20.0"
 launchdarkly-observability = ">=0.1.0"
 launchdarkly-server-sdk-ai-langchain = ">=0.6.0"
 langchain = "^1.0.0"

--- a/getting_started/openai/chat_completions/pyproject.toml
+++ b/getting_started/openai/chat_completions/pyproject.toml
@@ -13,7 +13,7 @@ openai = "openai_example:main"
 [tool.poetry.dependencies]
 python = "^3.10"
 python-dotenv = ">=1.0.0"
-launchdarkly-server-sdk-ai = ">=0.19.0"
+launchdarkly-server-sdk-ai = ">=0.20.0"
 launchdarkly-observability = ">=0.1.0"
 launchdarkly-server-sdk-ai-openai = ">=0.5.0"
 openai = ">=1.0.0"


### PR DESCRIPTION
## Summary
- Two examples (Bedrock Converse and LangGraph react agent) constructed `LDAIMetrics(..., usage=...)`. The Python `LDAIMetrics` dataclass never had a `usage` field — only `tokens` — so these constructors raise `TypeError` at runtime on current SDK.
- Likely copy-paste from Node docs, where the field is `tokens` post-0.20.
- `LDAIMetricSummary` (the read-side type returned to user code) DOES use `.usage` in Python — that's unchanged and intentional.

Refs AIC-2383. This PR is part of the AI Configs docs/example modernization sweep tracked in `python-agent-work/all-docs-review.md`.

## Test plan
- [ ] `python -m py_compile` on both files
- [ ] Run `bedrock_example.py` against `LAUNCHDARKLY_SDK_KEY` to confirm no `TypeError` on the metrics extractor path
- [ ] Same for `langgraph_agent_example.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)