### PR TITLE
fix: Use summary.tokens instead of summary.usage in examples

### DIFF
--- a/features/create_agent/create_agent_example.py
+++ b/features/create_agent/create_agent_example.py
@@ -85,10 +85,10 @@ async def async_main():
         print("\nMetrics tracked:")
         print(f"  Duration:      {summary.duration_ms}ms")
         print(f"  Success:       {summary.success}")
-        if summary.usage:
-            print(f"  Input tokens:  {summary.usage.input}")
-            print(f"  Output tokens: {summary.usage.output}")
-            print(f"  Total tokens:  {summary.usage.total}")
+        if summary.tokens:
+            print(f"  Input tokens:  {summary.tokens.input}")
+            print(f"  Output tokens: {summary.tokens.output}")
+            print(f"  Total tokens:  {summary.tokens.total}")
         if summary.tool_calls:
             print(f"  Tool calls:    {', '.join(summary.tool_calls)}")
 

--- a/features/create_agent_graph/create_agent_graph_example.py
+++ b/features/create_agent_graph/create_agent_graph_example.py
@@ -92,10 +92,10 @@ async def async_main():
             print(f"  Success:       {summary.success}")
         if summary.path:
             print(f"  Path:          {' -> '.join(summary.path)}")
-        if summary.usage:
-            print(f"  Input tokens:  {summary.usage.input}")
-            print(f"  Output tokens: {summary.usage.output}")
-            print(f"  Total tokens:  {summary.usage.total}")
+        if summary.tokens:
+            print(f"  Input tokens:  {summary.tokens.input}")
+            print(f"  Output tokens: {summary.tokens.output}")
+            print(f"  Total tokens:  {summary.tokens.total}")
 
         if summary.node_metrics:
             print("\nPer-node metrics:")
@@ -105,10 +105,10 @@ async def async_main():
                     print(f"    Duration:      {node_summary.duration_ms}ms")
                 if node_summary.success is not None:
                     print(f"    Success:       {node_summary.success}")
-                if node_summary.usage:
-                    print(f"    Input tokens:  {node_summary.usage.input}")
-                    print(f"    Output tokens: {node_summary.usage.output}")
-                    print(f"    Total tokens:  {node_summary.usage.total}")
+                if node_summary.tokens:
+                    print(f"    Input tokens:  {node_summary.tokens.input}")
+                    print(f"    Output tokens: {node_summary.tokens.output}")
+                    print(f"    Total tokens:  {node_summary.tokens.total}")
                 if node_summary.tool_calls:
                     print(f"    Tool calls:    {', '.join(node_summary.tool_calls)}")
 

--- a/getting_started/bedrock/converse/bedrock_example.py
+++ b/getting_started/bedrock/converse/bedrock_example.py
@@ -122,10 +122,10 @@ def main():
     print("\nDone! The AI config was evaluated and the following metrics were tracked:")
     print(f"  Duration:      {summary.duration_ms}ms")
     print(f"  Success:       {summary.success}")
-    if summary.usage:
-        print(f"  Input tokens:  {summary.usage.input}")
-        print(f"  Output tokens: {summary.usage.output}")
-        print(f"  Total tokens:  {summary.usage.total}")
+    if summary.tokens:
+        print(f"  Input tokens:  {summary.tokens.input}")
+        print(f"  Output tokens: {summary.tokens.output}")
+        print(f"  Total tokens:  {summary.tokens.total}")
     if summary.tool_calls:
         print(f"  Tool calls:    {', '.join(summary.tool_calls)}")
 

--- a/getting_started/gemini/generate_content/gemini_example.py
+++ b/getting_started/gemini/generate_content/gemini_example.py
@@ -177,10 +177,10 @@ def main():
     print("\nDone! The AI config was evaluated and the following metrics were tracked:")
     print(f"  Duration:      {summary.duration_ms}ms")
     print(f"  Success:       {summary.success}")
-    if summary.usage:
-        print(f"  Input tokens:  {summary.usage.input}")
-        print(f"  Output tokens: {summary.usage.output}")
-        print(f"  Total tokens:  {summary.usage.total}")
+    if summary.tokens:
+        print(f"  Input tokens:  {summary.tokens.input}")
+        print(f"  Output tokens: {summary.tokens.output}")
+        print(f"  Total tokens:  {summary.tokens.total}")
     if summary.tool_calls:
         print(f"  Tool calls:    {', '.join(summary.tool_calls)}")
 

--- a/getting_started/langchain/invoke/langchain_example.py
+++ b/getting_started/langchain/invoke/langchain_example.py
@@ -111,10 +111,10 @@ async def async_main():
         print("\nDone! The AI config was evaluated and the following metrics were tracked:")
         print(f"  Duration:      {summary.duration_ms}ms")
         print(f"  Success:       {summary.success}")
-        if summary.usage:
-            print(f"  Input tokens:  {summary.usage.input}")
-            print(f"  Output tokens: {summary.usage.output}")
-            print(f"  Total tokens:  {summary.usage.total}")
+        if summary.tokens:
+            print(f"  Input tokens:  {summary.tokens.input}")
+            print(f"  Output tokens: {summary.tokens.output}")
+            print(f"  Total tokens:  {summary.tokens.total}")
         if summary.tool_calls:
             print(f"  Tool calls:    {', '.join(summary.tool_calls)}")
 

--- a/getting_started/langgraph/react_agent/langgraph_agent_example.py
+++ b/getting_started/langgraph/react_agent/langgraph_agent_example.py
@@ -114,10 +114,10 @@ def main():
         print("\nDone! The agent config was evaluated and the following metrics were tracked:")
         print(f"  Duration:      {summary.duration_ms}ms")
         print(f"  Success:       {summary.success}")
-        if summary.usage:
-            print(f"  Input tokens:  {summary.usage.input}")
-            print(f"  Output tokens: {summary.usage.output}")
-            print(f"  Total tokens:  {summary.usage.total}")
+        if summary.tokens:
+            print(f"  Input tokens:  {summary.tokens.input}")
+            print(f"  Output tokens: {summary.tokens.output}")
+            print(f"  Total tokens:  {summary.tokens.total}")
         if summary.tool_calls:
             print(f"  Tool calls:    {', '.join(summary.tool_calls)}")
 

--- a/getting_started/langgraph/state_graph/langgraph_multi_agent_example.py
+++ b/getting_started/langgraph/state_graph/langgraph_multi_agent_example.py
@@ -56,10 +56,10 @@ def track_langgraph_metrics(tracker, func, prev_message_count=0):
             new_messages = result["messages"][prev_message_count:]
             for message in new_messages:
                 metrics = get_ai_metrics_from_response(message)
-                if metrics.usage:
-                    total_input_tokens += metrics.usage.input
-                    total_output_tokens += metrics.usage.output
-                    total_tokens += metrics.usage.total
+                if metrics.tokens:
+                    total_input_tokens += metrics.tokens.input
+                    total_output_tokens += metrics.tokens.output
+                    total_tokens += metrics.tokens.total
         if total_tokens > 0:
             tracker.track_tokens(
                 TokenUsage(

--- a/getting_started/openai/chat_completions/openai_example.py
+++ b/getting_started/openai/chat_completions/openai_example.py
@@ -101,10 +101,10 @@ def main():
     print("\nDone! The AI config was evaluated and the following metrics were tracked:")
     print(f"  Duration:      {summary.duration_ms}ms")
     print(f"  Success:       {summary.success}")
-    if summary.usage:
-        print(f"  Input tokens:  {summary.usage.input}")
-        print(f"  Output tokens: {summary.usage.output}")
-        print(f"  Total tokens:  {summary.usage.total}")
+    if summary.tokens:
+        print(f"  Input tokens:  {summary.tokens.input}")
+        print(f"  Output tokens: {summary.tokens.output}")
+        print(f"  Total tokens:  {summary.tokens.total}")
     if summary.tool_calls:
         print(f"  Tool calls:    {', '.join(summary.tool_calls)}")
 


### PR DESCRIPTION
## Summary
- The agent-graph example reads `summary.usage` / `node_summary.usage`, but the SDK exposes these as `summary.tokens` / `node_summary.tokens`. PR #30 fixed LDAIMetrics constructors but missed these read sites. Without this fix the example crashes with AttributeError when it reaches the metrics print block.
- The same stale `.usage` read appears on metric-summary objects across the other examples (create_agent, langgraph react + multi-agent, langchain, openai, bedrock, gemini); all are updated to `.tokens` here so the whole example suite stays consistent.

## Test plan
- [ ] Run `poetry run agent-graph` against a project with a configured agent graph; verify token counts print without AttributeError.

🤖 Generated with [Claude Code](https://claude.com/claude-code)