### PR TITLE
fix: Drop await from LDAIClient factory calls

### DIFF
--- a/features/create_agent/create_agent_example.py
+++ b/features/create_agent/create_agent_example.py
@@ -63,8 +63,8 @@ async def async_main():
         #       provider={'name': 'openai'},
         #       instructions='You are a helpful weather assistant.',
         #   )
-        #   agent = await aiclient.create_agent(agent_config_key, context, tools={'get_weather': get_weather}, default=default)
-        agent = await aiclient.create_agent(
+        #   agent = aiclient.create_agent(agent_config_key, context, tools={'get_weather': get_weather}, default=default)
+        agent = aiclient.create_agent(
             agent_config_key,
             context,
             tools={'get_weather': get_weather},

--- a/features/create_agent/pyproject.toml
+++ b/features/create_agent/pyproject.toml
@@ -13,7 +13,7 @@ agent = "create_agent_example:main"
 [tool.poetry.dependencies]
 python = "^3.10"
 python-dotenv = ">=1.0.0"
-launchdarkly-server-sdk-ai = ">=0.20.0"
+launchdarkly-server-sdk-ai = ">=0.21.0"
 launchdarkly-observability = ">=0.1.0"
 launchdarkly-server-sdk-ai-openai = {version = ">=0.5.0", extras = ["agents"]}
 launchdarkly-server-sdk-ai-langchain = ">=0.6.0"

--- a/features/create_agent/pyproject.toml
+++ b/features/create_agent/pyproject.toml
@@ -13,7 +13,7 @@ agent = "create_agent_example:main"
 [tool.poetry.dependencies]
 python = "^3.10"
 python-dotenv = ">=1.0.0"
-launchdarkly-server-sdk-ai = ">=0.21.0"
+launchdarkly-server-sdk-ai = ">=1.0.0,<2.0.0"
 launchdarkly-observability = ">=0.1.0"
 launchdarkly-server-sdk-ai-openai = {version = ">=0.5.0", extras = ["agents"]}
 launchdarkly-server-sdk-ai-langchain = ">=0.6.0"

--- a/features/create_agent_graph/create_agent_graph_example.py
+++ b/features/create_agent_graph/create_agent_graph_example.py
@@ -63,7 +63,7 @@ async def async_main():
     )
 
     try:
-        graph = await aiclient.create_agent_graph(
+        graph = aiclient.create_agent_graph(
             graph_key,
             context,
             tools={

--- a/features/create_agent_graph/pyproject.toml
+++ b/features/create_agent_graph/pyproject.toml
@@ -13,7 +13,7 @@ agent-graph = "create_agent_graph_example:main"
 [tool.poetry.dependencies]
 python = "^3.10"
 python-dotenv = ">=1.0.0"
-launchdarkly-server-sdk-ai = ">=0.20.0"
+launchdarkly-server-sdk-ai = ">=0.21.0"
 launchdarkly-observability = ">=0.1.0"
 launchdarkly-server-sdk-ai-openai = {version = ">=0.5.0", extras = ["agents"]}
 launchdarkly-server-sdk-ai-langchain = {version = ">=0.6.0", extras = ["graph"]}

--- a/features/create_agent_graph/pyproject.toml
+++ b/features/create_agent_graph/pyproject.toml
@@ -13,7 +13,7 @@ agent-graph = "create_agent_graph_example:main"
 [tool.poetry.dependencies]
 python = "^3.10"
 python-dotenv = ">=1.0.0"
-launchdarkly-server-sdk-ai = ">=0.21.0"
+launchdarkly-server-sdk-ai = ">=1.0.0,<2.0.0"
 launchdarkly-observability = ">=0.1.0"
 launchdarkly-server-sdk-ai-openai = {version = ">=0.5.0", extras = ["agents"]}
 launchdarkly-server-sdk-ai-langchain = {version = ">=0.6.0", extras = ["graph"]}

--- a/features/create_model/create_model_example.py
+++ b/features/create_model/create_model_example.py
@@ -58,8 +58,8 @@ async def async_main():
         #       provider={'name': 'openai'},
         #       messages=[{'role': 'system', 'content': 'You are a helpful assistant.'}],
         #   )
-        #   chat = await aiclient.create_model(ai_config_key, context, default, {'companyName': 'LaunchDarkly'})
-        chat = await aiclient.create_model(ai_config_key, context, variables={
+        #   chat = aiclient.create_model(ai_config_key, context, default, {'companyName': 'LaunchDarkly'})
+        chat = aiclient.create_model(ai_config_key, context, variables={
             'companyName': 'LaunchDarkly',
         })
 

--- a/features/create_model/pyproject.toml
+++ b/features/create_model/pyproject.toml
@@ -13,7 +13,7 @@ model = "create_model_example:main"
 [tool.poetry.dependencies]
 python = "^3.10"
 python-dotenv = ">=1.0.0"
-launchdarkly-server-sdk-ai = ">=0.21.0"
+launchdarkly-server-sdk-ai = ">=1.0.0,<2.0.0"
 launchdarkly-observability = ">=0.1.0"
 launchdarkly-server-sdk-ai-openai = ">=0.5.0"
 launchdarkly-server-sdk-ai-langchain = ">=0.6.0"

--- a/features/create_model/pyproject.toml
+++ b/features/create_model/pyproject.toml
@@ -13,7 +13,7 @@ model = "create_model_example:main"
 [tool.poetry.dependencies]
 python = "^3.10"
 python-dotenv = ">=1.0.0"
-launchdarkly-server-sdk-ai = ">=0.20.0"
+launchdarkly-server-sdk-ai = ">=0.21.0"
 launchdarkly-observability = ">=0.1.0"
 launchdarkly-server-sdk-ai-openai = ">=0.5.0"
 launchdarkly-server-sdk-ai-langchain = ">=0.6.0"


### PR DESCRIPTION
## Summary

The `LDAIClient` factory methods `create_model`, `create_agent`, and `create_agent_graph` were converted from `async def` to plain `def` in `launchdarkly-server-sdk-ai` 1.0.0 — they do no async work, so the `await` was misleading. The `run()` methods on the returned `ManagedModel` / `ManagedAgent` / `ManagedAgentGraph` objects **remain async**.

This PR drops `await` from the three affected example call-sites in `features/`, updates the inline doc comments to match, and pins the SDK for those examples at `>=1.0.0,<2.0.0`.

## Requirements

Requires `launchdarkly-server-sdk-ai>=1.0.0` (released, on PyPI).

Related SDK PR: launchdarkly/python-server-sdk-ai#187 (`feat!: Make AI config factory methods synchronous`).

## Examples updated

- `features/create_model/create_model_example.py` — dropped `await` on `aiclient.create_model(...)`; pin bumped.
- `features/create_agent/create_agent_example.py` — dropped `await` on `aiclient.create_agent(...)`; pin bumped.
- `features/create_agent_graph/create_agent_graph_example.py` — dropped `await` on `aiclient.create_agent_graph(...)`; pin bumped.

`features/create_judge/` and all `getting_started/*` examples were untouched: `create_judge()` was already sync, and `getting_started/*` use the older `completion_config` / `agent_config` API rather than the factory methods, so they don't depend on the 1.0.0 release.

`async def async_main()` was kept as-is in all three updated examples — each still awaits `model.run()` / `agent.run()` / `graph.run()` and `response.evaluations`, so the function must remain async.

## End-to-end verification

Verified against the local SDK worktree (sync factory implementation) and re-verified that `poetry install` resolves `launchdarkly-server-sdk-ai 1.0.0` from PyPI in all three examples after pinning.

- `features/create_model` (`poetry run model` with `LAUNCHDARKLY_COMPLETION_KEY=sample-ai-config`) — full chat + judge evaluation flow ran successfully.
- `features/create_agent` (`poetry run agent` with `LAUNCHDARKLY_AGENT_KEY=sample-ai-config`) — factory call succeeded and `agent.run()` returned a response. The example then errored on `summary.usage` because the example file uses `.usage`, but the SDK renamed that attribute to `.tokens` in 0.20 ("Rename LDAIMetrics.usage and AIGraphMetrics.usage to .tokens"). This is a pre-existing example bug unrelated to this PR and should be addressed separately. (See the same `.usage` references in `features/create_agent_graph`.)
- `features/create_agent_graph` — not run end-to-end. The change is mechanical and identical in shape to the other two factories, and the same pre-existing `.usage` issue would prevent a clean run.

## Test plan

- [ ] CI passes.
- [ ] Spot-check one of the affected examples against the published 1.0.0 release.